### PR TITLE
Update cuda to 11.0

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -4,7 +4,7 @@
 build:
   # set to true if your model requires a GPU
   gpu: true
-  cuda: "10.1"
+  cuda: "11.0"
 
   # a list of ubuntu apt packages to install
   system_packages:


### PR DESCRIPTION
Thanks for the amazing model!

I'm not totally sure what the best way of handling compatibility issues with older and newer versions of cuda is but right now on a GTX 3090 due to this error https://github.com/pytorch/pytorch/issues/49161#issuecomment-742934261 you can't run this repo at all even in a docker image, but it works fine on 11.0 so I bumped it here :)